### PR TITLE
Update workspaces list max buffer to 5 MB

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -206,6 +206,7 @@ function listYarnBerryWorkspaces(directory: string): string[] {
     .execSync('yarn workspaces list --json', {
       cwd: directory,
       encoding: 'utf-8',
+      maxBuffer: 1024 * 1024, // 1MB
     })
     .split('\n')
   for (const line of lines) {
@@ -230,6 +231,7 @@ function listYarnWorkspaces(directory: string): string[] {
       child_process.execSync('yarn --silent --json workspaces info', {
         cwd: directory,
         encoding: 'utf-8',
+        maxBuffer: 1024 * 1024, // 1MB
       })
     ).data
   )

--- a/src/main.ts
+++ b/src/main.ts
@@ -206,7 +206,7 @@ function listYarnBerryWorkspaces(directory: string): string[] {
     .execSync('yarn workspaces list --json', {
       cwd: directory,
       encoding: 'utf-8',
-      maxBuffer: 1024 * 1024, // 1MB
+      maxBuffer: 1024 * 1024 * 5, // 5MB
     })
     .split('\n')
   for (const line of lines) {
@@ -231,7 +231,7 @@ function listYarnWorkspaces(directory: string): string[] {
       child_process.execSync('yarn --silent --json workspaces info', {
         cwd: directory,
         encoding: 'utf-8',
-        maxBuffer: 1024 * 1024, // 1MB
+        maxBuffer: 1024 * 1024 * 5, // 5MB
       })
     ).data
   )


### PR DESCRIPTION
On very large workspaces, the output of `yarn workspaces info` might not fit in the default buffer of 200 KB. This increases it to 5MB — which shouldn't have any inadvertent side effects.

### Test plan

Manually tested