### PR TITLE
Update typescript Dockerfile to latest node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@
 # MediaType: application/vnd.oci.image.index.v1+json
 # Digest:    sha256:a4b757cd491c7f0b57f57951f35f4e85b7e1ad54dbffca4cf9af0725e1650cd8
 # And use this digest in FROM
-ARG base_sha=a4b757cd491c7f0b57f57951f35f4e85b7e1ad54dbffca4cf9af0725e1650cd8
+ARG base_sha=9b741b28148b0195d62fa456ed84dd6c953c1f17a3761f3e6e6797a754d9edff
 
-FROM node:22.12.0-slim@sha256:${base_sha}
+FROM node:24.6.0-slim@sha256:${base_sha}
 
 ENV NODE_OPTIONS=--max-old-space-size=4096
 


### PR DESCRIPTION
Update to latest node image: https://hub.docker.com/layers/library/node/24.6.0-slim/images/sha256-527e3f1e925c5727a98b17575e68d0bb0b577965bf3b60330790bfcf8a0b3035

Not sure if we need to also update the pnpm/yarn/.tool-versions config files as part of this update?

### Test plan

Local build:
```
> docker buildx build --platform linux/amd64 -f Dockerfile -t scip-typescript:latest .

> docker run --rm -it --entrypoint /bin/sh scip-typescript:latest
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
# scip-typescript
Usage: scip-typescript [options] [command]

SCIP indexer for TypeScript and JavaScript
For usage examples, see https://github.com/sourcegraph/scip-typescript/blob/main/README.md

Options:
  -V, --version                  output the version number
  -h, --help                     display help for command

Commands:
  index [options] [projects...]
  help [command]                 display help for command
```

Using index digest:
```
> docker buildx imagetools inspect node:24.6.0-slim
Name:      docker.io/library/node:24.6.0-slim
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:9b741b28148b0195d62fa456ed84dd6c953c1f17a3761f3e6e6797a754d9edff
```