### PR TITLE
fix: ensure enclosing ranges contain occurrences

### DIFF
--- a/snapshots/output/enclosing-ranges-ts/index.ts
+++ b/snapshots/output/enclosing-ranges-ts/index.ts
@@ -1,9 +1,9 @@
 // < definition enclosing-ranges-ts 1.0.0 `index.ts`/
 
+// < start enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/
 // format-options: showRanges
 
 // < start enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/Foo#
-// < start enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/
 interface Foo {
 //        ^^^ definition enclosing-ranges-ts 1.0.0 `index.ts`/Foo#
   bar: string

--- a/snapshots/output/enclosing-ranges/range.js
+++ b/snapshots/output/enclosing-ranges/range.js
@@ -1,9 +1,9 @@
 // < definition enclosing-ranges 0.0.1 `range.js`/
 
+// < start enclosing_range enclosing-ranges 0.0.1 `range.js`/
 // format-options: showRanges
 
-// < start enclosing_range enclosing-ranges 0.0.1 `range.js`/
-//           ⌄ start enclosing_range enclosing-ranges 0.0.1 `range.js`/test.
+//    ⌄ start enclosing_range enclosing-ranges 0.0.1 `range.js`/test.
 const test = () => {
 //    ^^^^ definition enclosing-ranges 0.0.1 `range.js`/test.
   const a = 'a'
@@ -15,7 +15,7 @@ const test = () => {
 //       ^ reference local 2
 //           ^ reference local 5
 }
-//           ^ end enclosing_range enclosing-ranges 0.0.1 `range.js`/test.
+//    ^ end enclosing_range enclosing-ranges 0.0.1 `range.js`/test.
 
 // < start enclosing_range enclosing-ranges 0.0.1 `range.js`/test2().
 function test2() {

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -16,6 +16,7 @@ import {
 import { Input } from './Input'
 import { Packages } from './Packages'
 import { formatByteSizeAsHumanReadable } from './parseHumanByteSizeIntoNumber'
+import { Position } from './Position'
 import { Range } from './Range'
 import * as scip from './scip'
 import { ScipSymbol } from './ScipSymbol'
@@ -68,10 +69,14 @@ export class FileIndexer {
     if (symbol.isEmpty()) {
       return
     }
+    const sourceFileRange = Range.fromNode(this.sourceFile)
     this.pushOccurrence(
       new scip.scip.Occurrence({
         range: [0, 0, 0],
-        enclosing_range: Range.fromNode(this.sourceFile).toLsif(),
+        enclosing_range: new Range(
+          new Position(0, 0),
+          sourceFileRange.end
+        ).toLsif(),
         symbol: symbol.value,
         symbol_roles: scip.scip.SymbolRole.Definition,
       })
@@ -206,7 +211,7 @@ export class FileIndexer {
         declaration.initializer &&
         ts.isFunctionLike(declaration.initializer)
       ) {
-        enclosingRange = Range.fromNode(declaration.initializer).toLsif()
+        enclosingRange = Range.fromNode(declaration).toLsif()
       } else if (
         ts.isFunctionDeclaration(declaration) ||
         ts.isEnumDeclaration(declaration) ||

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -8,6 +8,7 @@ import { test } from 'uvu'
 
 import { Input } from './Input'
 import { indexCommand } from './main'
+import { Range } from './Range'
 import * as scip from './scip'
 import { formatSnapshot } from './SnapshotTesting'
 
@@ -74,6 +75,21 @@ for (const snapshotDirectory of snapshotDirectories) {
       throw new Error('empty LSIF index')
     }
     for (const document of index.documents) {
+      for (const occurrence of document.occurrences) {
+        if (occurrence.enclosing_range.length === 0) {
+          continue
+        }
+        const range = Range.fromLsif(occurrence.range)
+        const enclosingRange = Range.fromLsif(occurrence.enclosing_range)
+        if (
+          enclosingRange.start.compare(range.start) > 0 ||
+          enclosingRange.end.compare(range.end) < 0
+        ) {
+          throw new Error(
+            `enclosing range does not contain occurrence for ${occurrence.symbol} in ${document.relative_path}`
+          )
+        }
+      }
       const inputPath = path.join(inputRoot, document.relative_path)
       const relativeToInputDirectory = path.relative(inputDirectory, inputPath)
       const outputPath = path.resolve(outputDirectory, relativeToInputDirectory)


### PR DESCRIPTION
### Test plan

#### Reproduction

Use the existing enclosing-range fixture:

```ts
const test = () => {
  return 'value'
}
```

Before the fix, the occurrence covered `test`, while the enclosing range covered only the initializer:

```text
occurrence:       test
enclosing range:         () => { ... }
```

The source-file occurrence had the same problem when the file started with comments: its occurrence was at `[0,0,0]`, but its enclosing range started after the leading comments.

The new snapshot assertion fails when either malformed range is generated.

#### Verification

- Added an assertion that every emitted `enclosing_range` contains its occurrence.
- Updated the source-file and function-valued-variable snapshots.
- Ran `npm run test`: 31/31 passed.
- Ran `npm run build`.
- Ran `npm run prettier-check`.
- Ran `npm run eslint`.